### PR TITLE
Feature/add oauth provider

### DIFF
--- a/backend/src/main/kotlin/com/photograph/backend/config/security/component/OAuth2UserHandler.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/component/OAuth2UserHandler.kt
@@ -13,8 +13,9 @@ class OAuth2UserHandler(private val memberService: MemberService) : DefaultOAuth
 
     override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
         val oAuth2User = super.loadUser(userRequest)
-        val member = memberService.merge(MemberMapper.toDomain(oAuth2User))
+        val provider = userRequest.clientRegistration.clientName
 
-        return MemberPrincipal(member)
+        return memberService.merge(MemberMapper.toDomain(oAuth2User, provider))
+            .run { MemberPrincipal(this) }
     }
 }

--- a/backend/src/main/kotlin/com/photograph/backend/config/security/domain/MemberPrincipal.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/domain/MemberPrincipal.kt
@@ -13,6 +13,7 @@ data class MemberPrincipal(
         mutableMapOf(
             "username" to name,
             "email" to email,
+            "providerKey" to providerKey
         )
     }
 

--- a/backend/src/main/kotlin/com/photograph/backend/member/domain/Member.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/member/domain/Member.kt
@@ -3,4 +3,6 @@ package com.photograph.backend.member.domain
 data class Member(
     val name: String,
     val email: String,
+    val provider: String,
+    val providerKey: String,
 )

--- a/backend/src/main/kotlin/com/photograph/backend/member/domain/MemberMapper.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/member/domain/MemberMapper.kt
@@ -7,22 +7,28 @@ object MemberMapper {
     fun toDomain(memberDocument: MemberDocument) = with(memberDocument) {
         Member(
             name = name,
-            email = email
+            email = email,
+            provider = provider,
+            providerKey = providerKey
         )
     }
 
     /**
      * @param oAuth2User sub, name, given_name, family_name, picture, email, email_verified
      */
-    fun toDomain(oAuth2User: OAuth2User) = Member(
+    fun toDomain(oAuth2User: OAuth2User, provider: String) = Member(
         name = oAuth2User.attributes["name"] as String,
         email = oAuth2User.attributes["email"] as String,
+        provider = provider,
+        providerKey = oAuth2User.name
     )
 
     fun toEntity(member: Member) = with(member) {
         MemberDocument(
             name = name,
-            email = email
+            email = email,
+            provider = provider,
+            providerKey = providerKey
         )
     }
 }

--- a/backend/src/main/kotlin/com/photograph/backend/member/domain/MemberService.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/member/domain/MemberService.kt
@@ -6,14 +6,18 @@ import org.springframework.stereotype.Service
 @Service
 class MemberService(private val memberRepository: MemberRepository) {
     fun merge(member: Member): Member {
-        return findByName(member.name)?.let { return it }
-            ?: memberRepository.save(MemberMapper.toEntity(member))
-                .run { MemberMapper.toDomain(this) }
+        return findByProviderKey(member.provider, member.providerKey)
+            ?.let { member }
+            ?: run { save(member) }
     }
 
-    fun findByName(name: String): Member? {
-        return memberRepository.findByName(name)?.let {
-            MemberMapper.toDomain(it)
-        }
+    fun findByProviderKey(provider: String, providerKey: String): Member? {
+        return memberRepository.findByProviderAndProviderKey(provider, providerKey)
+            ?.let { MemberMapper.toDomain(it) }
+    }
+
+    fun save(member: Member): Member {
+        return memberRepository.save(MemberMapper.toEntity(member))
+            .run { MemberMapper.toDomain(this) }
     }
 }

--- a/backend/src/main/kotlin/com/photograph/backend/member/infra/MemberDocument.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/member/infra/MemberDocument.kt
@@ -12,4 +12,6 @@ data class MemberDocument(
     val name: String,
     val email: String,
     val createdAt: LocalDateTime = LocalDateTime.now(),
+    val provider: String,
+    val providerKey: String,
 )

--- a/backend/src/main/kotlin/com/photograph/backend/member/infra/MemberDocument.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/member/infra/MemberDocument.kt
@@ -2,10 +2,12 @@ package com.photograph.backend.member.infra
 
 import org.bson.types.ObjectId
 import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.CompoundIndex
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
 
 @Document(value = "member")
+@CompoundIndex(name = "providerWithKey", def = "{'provider': 1, 'providerKey': 1}", unique = true)
 data class MemberDocument(
     @Id
     val memberId: String = ObjectId().toString(),

--- a/backend/src/main/kotlin/com/photograph/backend/member/infra/MemberRepository.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/member/infra/MemberRepository.kt
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface MemberRepository : MongoRepository<MemberDocument, String> {
-    fun findByName(name: String): MemberDocument?
+    fun findByProviderAndProviderKey(provider: String, providerKey: String): MemberDocument?
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -3,4 +3,6 @@ spring:
     name: backend
 server:
   port: 8088
-
+logging:
+  level:
+    org.springframework.data.mongodb: DEBUG

--- a/backend/src/test/kotlin/com/photograph/backend/member/domain/MemberServiceTest.kt
+++ b/backend/src/test/kotlin/com/photograph/backend/member/domain/MemberServiceTest.kt
@@ -11,7 +11,7 @@ class MemberServiceTest : DescribeSpec({
 
     val memberRepository: MemberRepository = mockk()
     val entity: MemberDocument = mockk(relaxed = true)
-    val member = Member("정명", "jeongmyeong@gmail.com")
+    val member = Member("정명", "jeongmyeong@gmail.com", "google", "google-sub")
 
     describe("회원정보 서비스는") {
         val service = MemberService(memberRepository)

--- a/backend/src/test/kotlin/com/photograph/backend/member/domain/MemberServiceTest.kt
+++ b/backend/src/test/kotlin/com/photograph/backend/member/domain/MemberServiceTest.kt
@@ -17,7 +17,7 @@ class MemberServiceTest : DescribeSpec({
         val service = MemberService(memberRepository)
 
         context("회원정보가 있으면") {
-            every { memberRepository.findByName(any()) } returns entity
+            every { memberRepository.findByProviderAndProviderKey(any(), any()) } returns entity
 
             service.merge(member)
 
@@ -27,7 +27,7 @@ class MemberServiceTest : DescribeSpec({
         }
 
         context("회원정보가 없으면") {
-            every { memberRepository.findByName(any()) } returns null
+            every { memberRepository.findByProviderAndProviderKey(any(), any()) } returns null
             every { memberRepository.save(any()) } returns entity
 
             service.merge(member)


### PR DESCRIPTION
회원에 oAuth Provider + ProviderKey 필드 추가
회원 도큐먼트에 복합 유니크 인덱스 추가
```yaml
application-local.yaml에 추가

  data:
    mongodb:
      auto-index-creation: true
```
복합키로 회원을 찾아오는 메서드 생성 및 findByName 제거