### PR TITLE
19 add failure handler

### DIFF
--- a/backend/src/main/kotlin/com/photograph/backend/config/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/SecurityConfig.kt
@@ -34,7 +34,7 @@ class SecurityConfig(
                 authorizeRequests
                     .requestMatchers("/api/**").permitAll()
                     .requestMatchers("/admin/**").hasRole("ADMIN")
-                    .anyRequest().permitAll()
+                    .anyRequest().authenticated()
             }
             .exceptionHandling { it.authenticationEntryPoint(oauthAuthenticationEntryPoint) }
             .build()

--- a/backend/src/main/kotlin/com/photograph/backend/config/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/SecurityConfig.kt
@@ -2,6 +2,7 @@ package com.photograph.backend.config.security
 
 import com.photograph.backend.config.security.component.AuthenticationSuccessHandler
 import com.photograph.backend.config.security.component.OAuth2UserHandler
+import com.photograph.backend.config.security.component.Oauth2LogoutHandler
 import com.photograph.backend.config.security.component.OauthAuthenticationEntryPoint
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -10,9 +11,10 @@ import org.springframework.security.web.DefaultSecurityFilterChain
 
 @Configuration
 class SecurityConfig(
+    private val corsAllowConfiguration: CorsConfig,
+    private val oauth2LogoutHandler: Oauth2LogoutHandler,
     private val oAuth2UserHandler: OAuth2UserHandler,
     private val authenticationSuccessHandler: AuthenticationSuccessHandler,
-    private val corsAllowConfiguration: CorsConfig,
     private val oauthAuthenticationEntryPoint: OauthAuthenticationEntryPoint,
 ) {
 
@@ -27,12 +29,14 @@ class SecurityConfig(
                     .successHandler(authenticationSuccessHandler) // 성공 핸들러
                     .userInfoEndpoint { it.userService(oAuth2UserHandler) } // 사용자 정보를 가져오는 서비스
             }
+            .logout { it.logoutSuccessHandler(oauth2LogoutHandler) }
             .authorizeHttpRequests { authorizeRequests ->
                 authorizeRequests
                     .requestMatchers("/api/**").permitAll()
                     .requestMatchers("/admin/**").hasRole("ADMIN")
-                    .anyRequest().authenticated()
+                    .anyRequest().permitAll()
             }
             .exceptionHandling { it.authenticationEntryPoint(oauthAuthenticationEntryPoint) }
             .build()
+
 }

--- a/backend/src/main/kotlin/com/photograph/backend/config/security/component/LogoutHandler.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/component/LogoutHandler.kt
@@ -15,10 +15,8 @@ class Oauth2LogoutHandler : LogoutSuccessHandler {
         response: HttpServletResponse?,
         authentication: Authentication?
     ) {
-        val cookieClearingLogoutHandler = CookieClearingLogoutHandler("JSESSIONID")
-        val securityContextLogoutHandler = SecurityContextLogoutHandler()
-        cookieClearingLogoutHandler.logout(request, response, authentication)
-        securityContextLogoutHandler.logout(request, response, authentication)
+        CookieClearingLogoutHandler("JSESSIONID").logout(request, response, authentication)
+        SecurityContextLogoutHandler().logout(request, response, authentication)
         response?.status = HttpServletResponse.SC_OK
     }
 }

--- a/backend/src/main/kotlin/com/photograph/backend/config/security/component/LogoutHandler.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/component/LogoutHandler.kt
@@ -1,0 +1,24 @@
+package com.photograph.backend.config.security.component
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.logout.CookieClearingLogoutHandler
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler
+import org.springframework.stereotype.Component
+
+@Component
+class Oauth2LogoutHandler : LogoutSuccessHandler {
+    override fun onLogoutSuccess(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        authentication: Authentication?
+    ) {
+        val cookieClearingLogoutHandler = CookieClearingLogoutHandler("JSESSIONID")
+        val securityContextLogoutHandler = SecurityContextLogoutHandler()
+        cookieClearingLogoutHandler.logout(request, response, authentication)
+        securityContextLogoutHandler.logout(request, response, authentication)
+        response?.status = HttpServletResponse.SC_OK
+    }
+}

--- a/backend/src/main/kotlin/com/photograph/backend/config/security/component/Oauth2LogoutHandler.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/component/Oauth2LogoutHandler.kt
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Component
 @Component
 class Oauth2LogoutHandler : LogoutSuccessHandler {
     override fun onLogoutSuccess(
-        request: HttpServletRequest?,
-        response: HttpServletResponse?,
-        authentication: Authentication?
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication
     ) {
         CookieClearingLogoutHandler("JSESSIONID").logout(request, response, authentication)
         SecurityContextLogoutHandler().logout(request, response, authentication)
-        response?.status = HttpServletResponse.SC_OK
+        response.status = HttpServletResponse.SC_OK
     }
 }

--- a/backend/src/main/kotlin/com/photograph/backend/config/security/component/OauthAuthenticationEntryPoint.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/component/OauthAuthenticationEntryPoint.kt
@@ -2,6 +2,7 @@ package com.photograph.backend.config.security.component
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.stereotype.Component
@@ -15,7 +16,7 @@ class OauthAuthenticationEntryPoint : AuthenticationEntryPoint {
     ) {
         val errorMessage = authException?.message ?: "Unauthorized"
         response?.apply {
-            contentType = "application/json"
+            contentType = APPLICATION_JSON_VALUE
             status = HttpServletResponse.SC_UNAUTHORIZED
             writer.write("{\"message\": \"$errorMessage\"}")
         }

--- a/backend/src/main/kotlin/com/photograph/backend/config/security/component/OauthAuthenticationEntryPoint.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/component/OauthAuthenticationEntryPoint.kt
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Component
 @Component
 class OauthAuthenticationEntryPoint : AuthenticationEntryPoint {
     override fun commence(
-        request: HttpServletRequest?,
-        response: HttpServletResponse?,
-        authException: AuthenticationException?
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
     ) {
-        val errorMessage = authException?.message ?: "Unauthorized"
-        response?.apply {
+        val errorMessage = authException.message ?: "Unauthorized"
+        response.apply {
             contentType = APPLICATION_JSON_VALUE
             status = HttpServletResponse.SC_UNAUTHORIZED
             writer.write("{\"message\": \"$errorMessage\"}")

--- a/backend/src/main/kotlin/com/photograph/backend/config/security/component/OauthAuthenticationEntryPoint.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/component/OauthAuthenticationEntryPoint.kt
@@ -13,10 +13,11 @@ class OauthAuthenticationEntryPoint : AuthenticationEntryPoint {
         response: HttpServletResponse?,
         authException: AuthenticationException?
     ) {
+        val errorMessage = authException?.message ?: "Unauthorized"
         response?.apply {
             contentType = "application/json"
             status = HttpServletResponse.SC_UNAUTHORIZED
-            writer.write("{\"message\": \"Not Authorized\"}")
+            writer.write("{\"message\": \"$errorMessage\"}")
         }
     }
 }

--- a/backend/src/test/kotlin/com/photograph/backend/config/security/component/AuthenticationSuccessHandlerTest.kt
+++ b/backend/src/test/kotlin/com/photograph/backend/config/security/component/AuthenticationSuccessHandlerTest.kt
@@ -1,0 +1,29 @@
+package com.photograph.backend.config.security.component
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.Authentication
+
+class AuthenticationSuccessHandlerTest : DescribeSpec({
+
+    val redirectUrl = "http://localhost:5173"
+
+    describe("AuthenticationSuccessHandler 는") {
+        val handler = AuthenticationSuccessHandler(redirectUrl)
+
+        context("로그인에 성공하면") {
+            val request = MockHttpServletRequest()
+            val response = MockHttpServletResponse()
+            val authentication = mockk<Authentication>()
+
+            handler.onAuthenticationSuccess(request, response, authentication)
+
+            it("리다이렉트한다") {
+                response.getHeader("Location") shouldBe redirectUrl
+            }
+        }
+    }
+})

--- a/backend/src/test/kotlin/com/photograph/backend/config/security/component/Oauth2LogoutHandlerTest.kt
+++ b/backend/src/test/kotlin/com/photograph/backend/config/security/component/Oauth2LogoutHandlerTest.kt
@@ -1,0 +1,36 @@
+package com.photograph.backend.config.security.component
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+
+class Oauth2LogoutHandlerTest : DescribeSpec({
+    describe("Oauth2LogoutHandler 는") {
+        val handler = Oauth2LogoutHandler()
+
+        context("로그아웃에 성공하면") {
+            val request = MockHttpServletRequest()
+            val response = MockHttpServletResponse()
+            val authentication = mockk<Authentication>()
+
+            handler.onLogoutSuccess(request, response, authentication)
+
+            it("200응답을 반환한다") {
+                response.status shouldBe HttpServletResponse.SC_OK
+            }
+
+            it("JSESSIONID 쿠키를 삭제한다") {
+                response.cookies.find { it.name == "JSESSIONID" }?.maxAge shouldBe 0
+            }
+
+            it("SecurityContext 를 삭제한다") {
+                SecurityContextHolder.getContext().authentication shouldBe null
+            }
+        }
+    }
+})

--- a/frontend/src/views/Admin.vue
+++ b/frontend/src/views/Admin.vue
@@ -23,10 +23,8 @@ const test = () => {
 
 const logout = () => {
   instance.get('logout')
-    .then(response => {
-        if (response.status === 200) {
-          window.location.href = '/';
-        }
+    .then(_ => {
+        window.location.href = '/';
       })
 };
 

--- a/frontend/src/views/Admin.vue
+++ b/frontend/src/views/Admin.vue
@@ -2,6 +2,7 @@
   <div>
     {{ result }}
   </div>
+  <button @click="logout">Logout</button>
 </template>
 
 <script lang="ts" setup>
@@ -18,6 +19,15 @@ const test = () => {
       .catch(error => {
         result.value = error;
       });
+};
+
+const logout = () => {
+  instance.get('logout')
+    .then(response => {
+        if (response.status === 200) {
+          window.location.href = '/';
+        }
+      })
 };
 
 onMounted(() => {


### PR DESCRIPTION
로그아웃 버튼을 통해 인증 정보를 지우고 "/"로 리다이렉트 합니다.  
401 에러 발생시 동일한 Unauthorized가 아닌 발생한 에러의 메시지를 리턴합니다.  
기존의 쿠키 강제 삭제시 login?error로 리다이렉트 되던 이슈를 수정하였습니다. 