### PR TITLE
로그아웃 핸들링 추가

### DIFF
--- a/backend/src/main/kotlin/com/photograph/backend/config/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/SecurityConfig.kt
@@ -37,7 +37,10 @@ class SecurityConfig(
                         )
                     }
             }
-            .logout { it.logoutSuccessHandler(oauth2LogoutHandler) }
+            .logout {
+                it.logoutSuccessHandler(oauth2LogoutHandler)
+                    .invalidateHttpSession(true)
+            }
             .authorizeHttpRequests { authorizeRequests ->
                 authorizeRequests.requestMatchers("/api/**").permitAll()
                     .requestMatchers("/admin/**").hasRole("ADMIN")

--- a/backend/src/main/kotlin/com/photograph/backend/config/security/component/Oauth2LogoutHandler.kt
+++ b/backend/src/main/kotlin/com/photograph/backend/config/security/component/Oauth2LogoutHandler.kt
@@ -13,7 +13,7 @@ class Oauth2LogoutHandler : LogoutSuccessHandler {
     override fun onLogoutSuccess(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        authentication: Authentication
+        authentication: Authentication?
     ) {
         CookieClearingLogoutHandler("JSESSIONID").logout(request, response, authentication)
         SecurityContextLogoutHandler().logout(request, response, authentication)

--- a/frontend/src/js/axios.ts
+++ b/frontend/src/js/axios.ts
@@ -13,15 +13,13 @@ instance.interceptors.response.use(
         return response;
     },
     error => {
-        console.log(error)
-
-
-        if (error.response.status === 401) {
+        if (error.response && error.response.status === 401) {
             instance.get("/logout")
                 .then(_ => {
                     window.location.href = '/login';
                 })
         }
+
         return Promise.reject(error);
     }
 );


### PR DESCRIPTION
- authentication 정보가 없을 때 (request header 의 쿠키가 서버 세션에 없을 때) 도 cookie 를 비우는 response 생성하도록 수정
- 서버가 죽어서 error.response 객체가 없을 때는 별다른 처리를 하지 않도록 수정 (요청은 보냈지만 유효한 응답 자체가 네트워크 오류 등으로 없을 때)

closes #29, #30